### PR TITLE
Fix path to content_fields.html.twig

### DIFF
--- a/bundle/Resources/config/ez_field_templates.yml
+++ b/bundle/Resources/config/ez_field_templates.yml
@@ -3,4 +3,4 @@ system:
         fielddefinition_edit_templates:
             - template: "NetgenEnhancedBinaryFileBundle:admin:field_types.html.twig"
         field_templates:
-            - template: "NetgenEnhancedBinaryFileBundle:content_fields.html.twig"
+            - template: "NetgenEnhancedBinaryFileBundle::content_fields.html.twig"


### PR DESCRIPTION
Unfortunately my pull request introduced a bug because the path to the `content_fields.html.twig` file was missing a colon. The correct path is `NetgenEnhancedBinaryFileBundle::content_fields.html.twig`