### PR TITLE
Fix issue 14

### DIFF
--- a/bundle/Controller/DownloadController.php
+++ b/bundle/Controller/DownloadController.php
@@ -82,7 +82,7 @@ class DownloadController
         $filePath = $filePathNodes->item(0)->textContent;
         $fileName = basename($filePath);
 
-        $originalFilename = $originalFilenameNodes->length ? $originalFilenameNodes->item(0)->textContent : $fileName;
+        $originalFilename = html_entity_decode($originalFilenameNodes->length ? $originalFilenameNodes->item(0)->textContent : $fileName);
 
         $binaryFile = $this->ioService->loadBinaryFile('collected' . \DIRECTORY_SEPARATOR . $fileName);
 

--- a/bundle/FieldHandler/EnhancedBinaryFileHandler.php
+++ b/bundle/FieldHandler/EnhancedBinaryFileHandler.php
@@ -80,7 +80,9 @@ class EnhancedBinaryFileHandler implements CustomLegacyFieldHandlerInterface
         ];
 
         foreach ($fileInfo as $key => $binaryFileItem) {
-            $binaryFileElement = $doc->createElement($key, $binaryFileItem);
+            $cdataElement = $doc->createCDATASection($binaryFileItem);
+            $binaryFileElement = $doc->createElement($key);
+            $binaryFileElement->appendChild($cdataElement);
             $binaryFileList->appendChild($binaryFileElement);
         }
 


### PR DESCRIPTION
Fixes https://github.com/netgen/NetgenEnhancedBinaryFileBundle/issues/14 by wrapping the original filename into a cdata element so it won't produce broken xml when there are umlauts other other characters in the original filename that will produce html entities